### PR TITLE
Add basic e2e tests for spike

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,8 +15,18 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: Setup Just
+      uses: extractions/setup-just@v1
+      with:
+        just-version: 0.8.3
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
     - uses: actions/checkout@v2
     - name: Build
-      run: cargo build --verbose
-    - name: Run tests
-      run: cargo test --verbose
+      run: just build
+    - name: Run unit tests
+      run: just test
+    - name: Run e2e tests
+      run: just test-e2e

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,9 @@
+# Rust
 /target
+
+# Python
+__pycache__
+.venv
+
+# IDEs
+.idea

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,12 @@
+build:
+    cargo build --verbose
+
+run:
+    cargo run --bin fh-http
+
+test:
+    cargo test --verbose
+
+test-e2e:
+    pip install --requirement tests/requirements.txt
+    pytest tests

--- a/README.md
+++ b/README.md
@@ -31,3 +31,15 @@ RUST: modified request is: Request { headers: {"content-length": "9", "user-agen
 ```
 
 As you can see in the `modified request`, the method and the body is patched, as well as the `content-type` header.
+
+
+## Tests
+Invoke unit tests:
+```bash
+just test
+```
+
+Invoke end-to-end tests:
+```bash
+just test-e2e
+```

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,25 @@
+import tempfile
+
+import pytest
+from lovely.testlayers.server import ServerLayer
+
+
+class FlowHeaterLayer(ServerLayer):
+    def __init__(self):
+        stdout = tempfile.NamedTemporaryFile()
+        stderr = tempfile.NamedTemporaryFile()
+        super(FlowHeaterLayer, self).__init__(
+            name="fh-http",
+            servers=["localhost:3030"],
+            start_cmd="cargo run --bin fh-http",
+            stdout=stdout.name,
+            stderr=stderr.name,
+        )
+
+
+@pytest.fixture(scope="session")
+def fh_http():
+    server = FlowHeaterLayer()
+    server.setUp()
+    yield server
+    server.tearDown()

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,0 +1,3 @@
+pytest
+requests
+lovely-testlayers

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,0 +1,44 @@
+import requests
+from lovely.testlayers.server import ServerLayer
+
+
+def test_spike(fh_http: ServerLayer):
+
+    response = requests.post("http://localhost:3030/hello/xxx", json={"a": "b"})
+    data = response.json()
+
+    # Check HTTP response.
+    assert data["code"] == 200
+    assert data["headers"] == {}
+    assert data["body"] == [
+        116,
+        104,
+        105,
+        115,
+        32,
+        105,
+        115,
+        32,
+        116,
+        104,
+        101,
+        32,
+        112,
+        97,
+        116,
+        99,
+        104,
+        101,
+        100,
+        32,
+        98,
+        111,
+        100,
+        121,
+    ]
+
+    # Check STDOUT for fun.
+    fh_http.stdout.seek(0)
+    stdout = fh_http.stdout.read()
+    assert "DENO: Got request body" in stdout
+    assert "RUST: modified request is" in stdout


### PR DESCRIPTION
Hi there,

thanks for conceiving this excellent toolkit.

This adds a basic e2e test harness to verify request processing works. The machinery will have to be improved in upcoming iterations to have this actually make sense.

For example, we a) need to invoke specific Javascript files and b) return their transformation outcome using a special echo mode. However, it's still a start and maybe better than nothing.

With kind regards,
Andreas.
