### PR TITLE
Add REST endpoint for running request processors

### DIFF
--- a/fh-http/API.md
+++ b/fh-http/API.md
@@ -1,11 +1,6 @@
 # API spec for fh-http
 
-## Authentication
-- TODO
-
-## Admin endpoints
-
-### Request Processor Object
+## Request Processor Object
 
 ```json
 {
@@ -17,6 +12,18 @@
 }
 ```
 
+## Public endpoints
+**Run Request Processor**
+
+*Runs a previously stored request processor*
+
+- Request: `GET|POST|PUT|PATCH|DELETE|... /processor/{processor_id}/run`
+- Response: TBD
+
+## Admin endpoints
+
+### Authentication
+- TODO
 ### Endpoints
 **Create Request Processor**
 

--- a/fh-http/src/manager/request_processor.rs
+++ b/fh-http/src/manager/request_processor.rs
@@ -1,4 +1,5 @@
 use anyhow::Result;
+use fh_v8::{process_request, Request, Response};
 use serde::{self, Deserialize, Serialize};
 use sqlx::{pool::PoolConnection, Sqlite};
 use std::convert::AsRef;
@@ -114,4 +115,15 @@ pub(crate) async fn delete_request_processor(
     .await?;
 
     Ok(())
+}
+
+pub(crate) async fn run_request_processor(
+    conn: &mut PoolConnection<Sqlite>,
+    id: &Uuid,
+    request: Request,
+) -> Result<Response> {
+    let p = get_request_processor(conn, id).await?;
+    let res = process_request(request, Some(p.code)).await;
+
+    Ok(res)
 }

--- a/fh-http/src/server/public.rs
+++ b/fh-http/src/server/public.rs
@@ -2,12 +2,13 @@ pub(crate) mod filters {
     use crate::manager::{ReqCmd, ReqSender};
     use crate::server::with_sender;
     use fh_v8::Request;
+    use uuid::Uuid;
     use warp::{http, Filter};
 
     pub(crate) fn public_filters(
         tx: ReqSender<ReqCmd>,
     ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
-        process_request(tx.clone())
+        process_request_old(tx.clone()).or(run_request_processor(tx))
     }
 
     fn extract_request() -> impl Filter<Extract = (Request,), Error = warp::Rejection> + Copy {
@@ -34,7 +35,16 @@ pub(crate) mod filters {
             )
     }
 
-    pub(crate) fn process_request(
+    pub(crate) fn run_request_processor(
+        tx: ReqSender<ReqCmd>,
+    ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
+        warp::path!("processor" / Uuid / "run")
+            .and(with_sender(tx.clone()))
+            .and(extract_request())
+            .and_then(super::handlers::run_request_processor)
+    }
+
+    pub(crate) fn process_request_old(
         tx: ReqSender<ReqCmd>,
     ) -> impl Filter<Extract = impl warp::Reply, Error = warp::Rejection> + Clone {
         warp::path!("hello" / String)
@@ -48,7 +58,27 @@ pub(crate) mod handlers {
     use crate::manager::{ReqCmd, ReqSender};
     use fh_v8::Request;
     use tokio::sync::oneshot;
+    use uuid::Uuid;
     use warp::{Rejection, Reply};
+
+    pub(crate) async fn run_request_processor(
+        id: Uuid,
+        tx: ReqSender<ReqCmd>,
+        request: Request,
+    ) -> Result<impl Reply, Rejection> {
+        let mut tx2 = tx.lock().unwrap().clone();
+        let (cmd_tx, cmd_rx) = oneshot::channel();
+        tx2.send(ReqCmd::RunRequestProcessor {
+            id,
+            request,
+            cmd_tx,
+        })
+        .await
+        .unwrap();
+
+        let res = cmd_rx.await.unwrap().unwrap();
+        Ok(warp::reply::json(&res))
+    }
 
     pub(crate) async fn process_request(
         _name: String,

--- a/fh-v8/src/lib.rs
+++ b/fh-v8/src/lib.rs
@@ -62,7 +62,7 @@ impl From<http::Request<Vec<u8>>> for Request {
     }
 }
 
-pub async fn process_request(req: Request) -> Response {
+pub async fn process_request(req: Request, code: Option<String>) -> Response {
     let mut js_runtime = JsRuntime::new(Default::default());
 
     js_runtime.register_op(
@@ -79,9 +79,13 @@ pub async fn process_request(req: Request) -> Response {
 
     js_runtime.op_state().borrow_mut().put::<Request>(req);
 
-    js_runtime
-        .execute("flow_heater.js", include_str!("flow_heater.js"))
-        .unwrap();
+    if let Some(c) = code {
+        js_runtime.execute("custom_code.js", &c).unwrap();
+    } else {
+        js_runtime
+            .execute("flow_heater.js", include_str!("flow_heater.js"))
+            .unwrap();
+    }
 
     js_runtime.run_event_loop().await.unwrap();
 


### PR DESCRIPTION
* Introduces new REST endpoint `GET|POST|PUT|PATCH|DELETE|... /processor/{processor_id}/run`, which runs a previously stored request processor
* Closes #9 