### PR TITLE
Add specification for special "echo" mode

### DIFF
--- a/doc/spec/001-e2e-echo/e2e-echo-full.json5
+++ b/doc/spec/001-e2e-echo/e2e-echo-full.json5
@@ -1,0 +1,81 @@
+/*
+ * fh-core offers a special invocation style which can be used
+ * to test the outcome of its processing machinery.
+ *
+ * By invoking the designated HTTP endpoint with a special
+ * query argument like `__fh-echo__=true` or a request header
+ * like `FH-Echo: true`, the machinery will mask calls to
+ * `dispatch_request` and `respond_with` but instead will
+ * record their outcomes and return them as a JSON-serialized
+ * HTTP response.
+ *
+**/
+{
+  "requests": [
+    // Outcome from first invocation of `dispatch_request`.
+    // Derived from `http POST https://httpbin.org/anything foo=bar`.
+    {
+      "timestamp": "1985-04-12T23:20:50.52Z",
+      "args": {},
+      "data": "{\"foo\": \"bar\"}",
+      "files": {},
+      "form": {},
+      "headers": {
+        "Accept": "application/json, */*;q=0.5",
+        "Accept-Encoding": "gzip, deflate",
+        "Content-Length": "14",
+        "Content-Type": "application/json",
+        "Host": "httpbin.org",
+        "User-Agent": "HTTPie/2.3.0",
+        "X-Amzn-Trace-Id": "Root=1-5ff32db0-5b3642a1761e6cf3256911c6"
+      },
+      "json": {
+        "foo": "bar"
+      },
+      "method": "POST",
+      "origin": "87.122.102.169",
+      "url": "https://httpbin.org/anything"
+    },
+    // Outcome from second invocation of `dispatch_request`.
+    // Derived from `http POST https://httpbin.org/anything foo=bar baz==qux Content-Type:abc`.
+    {
+      "timestamp": "1985-04-12T23:20:50.58Z",
+      "args": {
+        "baz": "qux"
+      },
+      "data": "{\"foo\": \"bar\"}",
+      "files": {},
+      "form": {},
+      "headers": {
+        "Accept": "application/json, */*;q=0.5",
+        "Accept-Encoding": "gzip, deflate",
+        "Content-Length": "14",
+        "Content-Type": "abc",
+        "Host": "httpbin.org",
+        "User-Agent": "HTTPie/2.3.0",
+        "X-Amzn-Trace-Id": "Root=1-5ff32feb-12e643834a7a78f8418e6363"
+      },
+      "json": {
+        "foo": "bar"
+      },
+      "method": "POST",
+      "origin": "87.122.102.169",
+      "url": "https://httpbin.org/anything?baz=qux"
+    },
+  ],
+  // Outcome from invocation of `respond_with`.
+  // This outlines a response object when using a JSON response body.
+  "response": {
+    "timestamp": "1985-04-12T23:20:51.01Z",
+    "headers": {
+      "Access-Control-Allow-Credentials": "true",
+      "Access-Control-Allow-Origin": "*",
+      "Connection": "keep-alive",
+      "Content-Length": "498",
+      "Content-Type": "application/json",
+      "Date": "Mon, 04 Jan 2021 15:02:57 GMT",
+      "Server": "gunicorn/19.9.0",
+    },
+    "body": "{\"hello\": \"world\"}",
+  },
+}

--- a/doc/spec/001-e2e-echo/e2e-echo-request-binary.json5
+++ b/doc/spec/001-e2e-echo/e2e-echo-request-binary.json5
@@ -1,0 +1,33 @@
+{
+  "requests": [
+    // Outcome from first invocation of `dispatch_request`.
+    // Derived from:
+    // ```
+    // dd if=/dev/random of=tmpfile bs=1 count=42
+    // http --form POST https://httpbin.org/anything 'foobar@tmpfile'
+    // ```
+    {
+      "args": {},
+      "data": "",
+      "files": {
+        "foobar": "data:application/octet-stream;base64,4qpvEsH+Cxh857ZOgPaKEsigBHfDF7ubC9Y4dRn3aLnvdTYV7ntQ8df0"
+      },
+      "form": {},
+      "headers": {
+        "Accept": "*/*",
+        "Accept-Encoding": "gzip, deflate",
+        "Content-Length": "185",
+        "Content-Type": "multipart/form-data; boundary=294fa2b2bf2a43ac8025c31ff001de86",
+        "Host": "httpbin.org",
+        "User-Agent": "HTTPie/2.3.0",
+        "X-Amzn-Trace-Id": "Root=1-5ff37084-54fce2dc7e2472f7035ac285"
+      },
+      "json": null,
+      "method": "POST",
+      "origin": "87.122.102.169",
+      "url": "https://httpbin.org/anything"
+    },
+  ],
+  "response": {
+  },
+}

--- a/doc/spec/001-e2e-echo/e2e-echo-response-binary.json5
+++ b/doc/spec/001-e2e-echo/e2e-echo-response-binary.json5
@@ -1,0 +1,12 @@
+{
+  "requests": [
+  ],
+  // Outcome from invocation of `respond_with`.
+  // This outlines a response object when using a
+  // response body in binary/non-ASCII format.
+  "response": {
+    "headers": {
+    },
+    "body": "data:application/octet-stream;base64,eyJoZWxsbyI6ICJ3b3JsZCJ9Cg==",
+  },
+}

--- a/doc/spec/001-e2e-echo/e2e-readme.md
+++ b/doc/spec/001-e2e-echo/e2e-readme.md
@@ -1,0 +1,88 @@
+# Flow Heater e2e testing specification
+
+
+## Introduction
+As outlined within https://github.com/flow-heater/fh-core/pull/3#issuecomment-753533297:
+
+> The machinery will have to be improved in upcoming iterations to have this
+> actually make sense. For example, we a) need to invoke specific Javascript 
+> files and b) return their transformation outcome using a special echo mode.
+
+On this matter, it would be nice to be able to invoke the machinery by e.g. saying
+```bash
+cargo run --bin fh-http --echo --recipe=examples/scenario-01.js
+```
+in order to designate it should forward incoming requests to the recipe loaded 
+ad hoc from `examples/scenario-01.js` and echo the transformation outcome to 
+its HTTP response to be able to test it.
+
+That would be a kind of special isolated testing mode independently from the 
+"production mode" wired to the storage subsystem you are planning, where the 
+machinery would load recipes from a database and would forward the request 
+to another site (#1).
+
+The "echo" feature might work similar to what [httpbin](https://httpbin.org/) 
+is offering. Some examples based on [HTTPie](https://httpie.io/) to get an 
+idea how its response format looks like:
+```bash
+http POST https://httpbin.org/post foo=bar
+http POST https://httpbin.org/post?foo=bar baz==qux Content-Type:abc
+```
+
+
+## Elaboration
+We concluded that it would be nice to echo/return the content of 
+a) multiple requests created through multiple invocations of `dispatch_request` and
+b) a single response through the invocation of `respond_with`.
+
+Apart from being able to invoke the machinery from the command line 
+as outlined above, these mechanics might also well be implemented 
+through the real HTTP API, where just a single special parameter 
+would have to be attached as query argument like `?__fh-echo__=true`.
+
+
+## Specification
+
+### Magic request parameter 
+
+A full example would look like this:
+```
+http POST 'http://flow-heater.example.org/p/{processor_id}/run?__fh-echo__=true' foo=bar baz==qux
+```
+
+We used the "dunder" (double underscore) notation known from Python magic methods
+for designating this parameter in order to reduce the chance of collision with
+regular request parameters as we figured just using `echo` here might trigger
+that case more often than not.
+
+Alternatively, that magic parameter might as well be implemented
+as a special request header like `FH-Echo: true`.
+
+
+### Response payload
+We included three files `e2e-echo-full.json5`, `e2e-echo-request-binary.json5`
+and `e2e-echo-response-binary.json5` which outline appropriate JSON payloads 
+how things might look like on the response side.
+
+The `request` snippets have been derived from responses to HTTPBin's
+`/anything` endpoint.
+
+As a bonus, each object might optionally attach a `timestamp` attribute in
+RFC3339 format.
+
+#### Encoding binary data bodies
+We concluded that the `body` attribute of the `response` object should be able
+to also carry responses in binary/non-ASCII format independently of the original 
+`Content-Type` or `Content-Encoding` response headers in order to be able to 
+serialize binary contents into the JSON file.
+
+`e2e-echo-response-binary.json5` gives an example for that. It aligns with
+`e2e-echo-request-binary.json5`, both use a prefix like
+`data:application/octet-stream;base64,...`, thus applying the [data URI scheme]. 
+
+[data URI scheme]: https://en.wikipedia.org/wiki/Data_URI_scheme
+
+#### Notes
+While we wrote those specification files in JSON5 format for being able
+to include inline comments, the real implementation will probably use
+plain JSON.


### PR DESCRIPTION
Hi there,

coming from https://github.com/flow-heater/fh-core/pull/3#issuecomment-753533297, this adds a specification outlining a special "echo" mode to the processing machinery.

That mode will unlock the ability to test the transformation machinery thoroughly, for both invocations of `dispatch_request` and `respond_with`.

I hope this helps for implementing that feature and I will be happy to receive any feedback on it.

With kind regards,
Andreas.

P.S.: While the single public endpoint documented at [1] uses the `/processor/{processor_id}` URL prefix, I deliberately shortened that to just use `/p/{processor_id}` within this specification.

[1] https://github.com/flow-heater/fh-core/blob/main/fh-http/API.md#public-endpoints
