### PR TITLE
use local venv for python dependencies

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -17,5 +17,7 @@ test:
     cargo test --verbose
 
 test-e2e:
-    pip install --requirement tests/requirements.txt
-    pytest tests
+    python3 -m venv .venv
+    .venv/bin/pip install --upgrade pip
+    .venv/bin/pip install --requirement tests/requirements.txt
+    .venv/bin/pytest tests

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,4 @@
 pytest
 requests
 lovely-testlayers
+black

--- a/tests/test_run_processor.py
+++ b/tests/test_run_processor.py
@@ -17,7 +17,11 @@ def test_run_processor(fh_http: ServerLayer):
     """
 
     rp = RequestProcessor(
-        id=None, name="testing", runtime="v8", language="javascript", code=code,
+        id=None,
+        name="testing",
+        runtime="v8",
+        language="javascript",
+        code=code,
     )
 
     response = create_request_processor(rp)
@@ -52,7 +56,11 @@ def test_json_availablity(fh_http: ServerLayer):
     """
 
     rp = RequestProcessor(
-        id=None, name="testing", runtime="v8", language="javascript", code=code,
+        id=None,
+        name="testing",
+        runtime="v8",
+        language="javascript",
+        code=code,
     )
 
     response = create_request_processor(rp)
@@ -69,4 +77,3 @@ def test_json_availablity(fh_http: ServerLayer):
     print(stdout)
     assert 'Stringify: {"a":"b"}' in stdout
     assert "Parse works, too" in stdout
-


### PR DESCRIPTION
@amotl  for local development, I added black as a formatter and did everything within a local virtual env to avoid clash with the global pip space.