### PR TITLE
Improve runtime of "test-e2e" recipe

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -53,8 +53,6 @@ jobs:
           python-version: 3.8
 
       # Setup sqlx and run db migrations.
-      - name: Install sqlx cli
-        run: '(test -f ~/.cargo/bin/sqlx) || cargo install sqlx-cli'
       - name: Create DB and run migrations
         run: just db
 


### PR DESCRIPTION
Hi.

By only creating the virtualenv if it doesn't exist, this will speed up subsequent invocations of "just test-e2e". Also, the "db" recipe will install the "sqlx-cli" on demand beforehand.

With kind regards,
Andreas.