### PR TITLE
Fix tests: Reset STDOUT capture file before each test function

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,3 +23,8 @@ def fh_http():
     server.setUp()
     yield server
     server.tearDown()
+
+
+@pytest.fixture(scope="function", autouse=True)
+def fh_stdout(fh_http):
+    fh_http.stdout.truncate(0)


### PR DESCRIPTION
This is important. Otherwise checking the test outcomes might yield wrong results.