### PR TITLE
Slightly improve and generalize recipe/processor testing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,1 @@
-DATABASE_URL="sqlite:fh-http.db"
+DATABASE_URL="sqlite:./var/lib/fh-http.db"

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,5 @@ __pycache__
 .idea
 .vscode
 
-# sqlite
-fh-http.db*
+# database
+/var

--- a/Justfile
+++ b/Justfile
@@ -5,6 +5,7 @@ dotenv:
 
 db: dotenv
     @test -e ~/.cargo/bin/sqlx || cargo install sqlx-cli
+    @mkdir -p var/lib
     sqlx db create
     sqlx migrate run
 
@@ -32,7 +33,7 @@ pytest       := venvpath + "/bin/pytest"
 
 test-e2e: setup-virtualenv build
     @echo "Running e2e tests."
-    @{{pytest}} tests
+    @{{pytest}} tests -vvvv
 
 # Setup Python virtualenv
 setup-virtualenv:

--- a/README.md
+++ b/README.md
@@ -50,3 +50,8 @@ Invoke end-to-end tests:
 ```bash
 just test-e2e
 ```
+
+Invoke specific tests:
+```bash
+pytest -k examples_basic -vvv
+```

--- a/examples/01-basic/error-runtime.js
+++ b/examples/01-basic/error-runtime.js
@@ -1,0 +1,1 @@
+JSON.foobar();

--- a/examples/01-basic/error-syntax.js
+++ b/examples/01-basic/error-syntax.js
@@ -1,0 +1,1 @@
+Hello world!

--- a/examples/01-basic/json-demo.js
+++ b/examples/01-basic/json-demo.js
@@ -1,0 +1,14 @@
+// A basic example demonstrating `JSON.stringify()` and `JSON.parse()`.
+
+const data = {"a": "b"};
+const stringified = JSON.stringify(data);
+const matches = (obj, source) =>
+    Object.keys(source).every(key => obj.hasOwnProperty(key) && obj[key] === source[key]);
+
+Deno.core.print(`Stringify: ${stringified}\n`);
+
+if (matches(JSON.parse(stringified), data)) {
+    Deno.core.print(`Parse works, too\n`);
+} else {
+    Deno.core.print(`PvD: ${JSON.parse(stringified)} v ${data}\n`);
+}

--- a/examples/01-basic/json-request-echo.js
+++ b/examples/01-basic/json-request-echo.js
@@ -1,0 +1,5 @@
+// A basic example returning the request details as JSON on STDOUT.
+
+Deno.core.ops();
+let request = Deno.core.jsonOpSync("get_request", []);
+Deno.core.print(JSON.stringify(request));

--- a/fh-v8/src/lib.rs
+++ b/fh-v8/src/lib.rs
@@ -97,7 +97,7 @@ pub async fn process_request(req: Request, code: Option<String>) -> Result<Respo
     let state = js_runtime.op_state();
     let op_state = state.borrow();
     let modified_req = op_state.borrow::<Request>();
-    println!("RUST: modified request is: {:?}", modified_req);
+    //println!("RUST: modified request is: {:?}", modified_req);
 
     Ok(Response {
         code: 200,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,14 @@ class FlowHeaterLayer(ServerLayer):
             stderr=stderr,
         )
 
+    def get_stdout(self, strip_nulls=True):
+        self.stdout.seek(0)
+        payload = self.stdout.read()
+        # FIXME: There are a bunch of null-bytes at the beginning of STDOUT. Why?
+        if strip_nulls:
+            payload = payload.strip("\x00")
+        return payload
+
 
 @pytest.fixture(scope="session")
 def fh_http():

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -41,4 +41,4 @@ def test_spike(fh_http: ServerLayer):
     fh_http.stdout.seek(0)
     stdout = fh_http.stdout.read()
     assert "DENO: Got request body" in stdout
-    assert "RUST: modified request is" in stdout
+    #assert "RUST: modified request is" in stdout

--- a/tests/test_examples_basic.py
+++ b/tests/test_examples_basic.py
@@ -1,0 +1,132 @@
+import json
+from pathlib import Path
+
+from tests.conftest import FlowHeaterLayer
+from tests.util import execute
+
+basedir = Path("examples/01-basic")
+
+
+def test_error_syntax(fh_http: FlowHeaterLayer):
+    """
+    $ deno run examples/01-basic/error-syntax.js
+    error: Expected ';', '}' or <eof> at file:///Users/amo/dev/flow-heater/fh-core/examples/01-basic/error-syntax.js:1:6
+
+    As this is actually a linter error, respective code should not
+    even make it to runtime when already caught on insertion time.
+    See https://github.com/flow-heater/fh-core/issues/22.
+    """
+
+    response = execute(basedir / "error-syntax.js", headers={"FH-Debug": "true"})
+
+    assert response.status_code == 500
+    data = response.json()
+
+    # TODO: That might yield a linter error after the HTTP request
+    #       header "FH-Debug: true" will get evaluated appropriately.
+
+
+def test_error_runtime(fh_http: FlowHeaterLayer):
+    """
+    $ deno run examples/01-basic/error-runtime.js
+    error: Uncaught TypeError: JSON.foobar is not a function
+    JSON.foobar();
+         ^
+        at file:///Users/amo/dev/flow-heater/fh-core/examples/01-basic/error-runtime.js:1:6
+
+    For propagating those runtime errors to the user interactively,
+    I've elaborated on the `FH-Debug: true` header within
+    https://github.com/flow-heater/fh-core/issues/33.
+    """
+
+    response = execute(basedir / "error-runtime.js", headers={"FH-Debug": "true"})
+
+    assert response.status_code == 500
+    data = response.json()
+
+    # TODO: That might yield a stacktrace after the HTTP request
+    #       header "FH-Debug: true" will get evaluated appropriately.
+
+
+def test_json_demo(fh_http: FlowHeaterLayer):
+
+    response = execute(basedir / "json-demo.js")
+
+    assert response.status_code == 200
+    data = response.json()
+
+    # Check STDOUT
+    stdout = fh_http.get_stdout()
+    print(stdout)
+    assert 'Stringify: {"a":"b"}' in stdout
+    assert "Parse works, too" in stdout
+
+
+def test_json_request_get(fh_http: FlowHeaterLayer):
+
+    response = execute(basedir / "json-request-echo.js", headers={"foo": "bar"})
+
+    assert response.status_code == 200
+    data = response.json()
+
+    # Read STDOUT
+    stdout = fh_http.get_stdout()
+
+    # Check STDOUT
+    data = json.loads(stdout)
+    print(data)
+    assert data["method"] == "GET"
+    assert data["headers"]["user-agent"].startswith("python-requests/")
+    assert data["headers"]["foo"] == "bar"
+    assert data["body"] == ""
+
+
+def test_json_request_post(fh_http: FlowHeaterLayer):
+
+    response = execute(basedir / "json-request-echo.js", method="post")
+
+    assert response.status_code == 200
+    data = response.json()
+
+    # Read STDOUT
+    stdout = fh_http.get_stdout()
+
+    # Check STDOUT
+    data = json.loads(stdout)
+    print(data)
+    assert data["method"] == "POST"
+    assert data["body"] == ""
+
+
+def test_json_request_post_x_www_form_urlencoded(fh_http: FlowHeaterLayer):
+
+    response = execute(basedir / "json-request-echo.js", method="post", data={"foo": "bar"})
+
+    assert response.status_code == 200
+    data = response.json()
+
+    # Read STDOUT
+    stdout = fh_http.get_stdout()
+
+    # Check STDOUT
+    data = json.loads(stdout)
+    print(data)
+    assert data["method"] == "POST"
+    assert data["body"] == "foo=bar"
+
+
+def test_json_request_post_json(fh_http: FlowHeaterLayer):
+
+    response = execute(basedir / "json-request-echo.js", method="post", json={"foo": "bar"})
+
+    assert response.status_code == 200
+    data = response.json()
+
+    # Read STDOUT
+    stdout = fh_http.get_stdout()
+
+    # Check STDOUT
+    data = json.loads(stdout)
+    print(data)
+    assert data["method"] == "POST"
+    assert data["body"] == '{"foo": "bar"}'

--- a/tests/test_run_processor.py
+++ b/tests/test_run_processor.py
@@ -36,10 +36,10 @@ def test_run_processor(fh_http: ServerLayer):
     fh_http.stdout.seek(0)
     stdout = fh_http.stdout.read()
     assert "Hello from DENO" in stdout
-    assert "RUST: modified request is" in stdout
+    #assert "RUST: modified request is" in stdout
 
 
-def test_json_availablity(fh_http: ServerLayer):
+def test_json_availability(fh_http: ServerLayer):
     code = """
     const data = {"a": "b"};
     const stringified = JSON.stringify(data);

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,0 +1,37 @@
+import requests
+
+from tests.test_admin_processor import RequestProcessor, create_request_processor
+
+
+def read_code(filename):
+    with open(filename, "r") as f:
+        return f.read()
+
+
+def create_processor(filename):
+
+    code = read_code(filename)
+
+    rp = RequestProcessor(
+        id=None,
+        name="testing",
+        runtime="v8",
+        language="javascript",
+        code=code,
+    )
+
+    response = create_request_processor(rp)
+    rp_id = response.json()["id"]
+
+    return rp_id
+
+
+def run_processor(identifier, method="get", **kwargs):
+    response = requests.request(method, f"http://localhost:3030/processor/{identifier}/run", **kwargs)
+    return response
+
+
+def execute(filename, method="get", **kwargs):
+    identifier = create_processor(filename)
+    response = run_processor(identifier, method=method, **kwargs)
+    return response


### PR DESCRIPTION
Hi there,

this generalizes e2e testing by adding some convenience helper functions to `tests/util.py`. That will help a stack when churning out different kinds of individual JavaScript snippets and will save us from having to inline them into the Python test cases.

Instead, those JavaScript snippets can now be stored conveniently into the `examples/` directory.

With kind regards,
Andreas.
