### PR TITLE
Improve Justfile

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -1,23 +1,34 @@
 export RUST_BACKTRACE := "1"
 
+# The default recipe. Show all available recipes.
+default:
+    @echo
+    @just --list --unsorted
+    @echo
+
+# Automatically create `.env` file from `.env.example` blueprint.
 dotenv:
     @[ -f .env ] && echo "INFO: Will not overwrite existing .env file ..." || cp .env.example .env
 
+# Invoke DB migrations. Also create database if it doesn't exist yet.
 db: dotenv
     @test -e ~/.cargo/bin/sqlx || cargo install sqlx-cli
     @mkdir -p var/lib
     sqlx db create
     sqlx migrate run
 
+# Build the Rust program.
 build: db
     @echo
     @echo "INFO: Building the Rust program. On the first invocation, this might take quite a while."
     @echo
     cargo build
 
+# Run the Rust program.
 run: dotenv db
     cargo run --bin fh-http
 
+# Run unit tests.
 test:
     cargo test --verbose
 
@@ -26,16 +37,20 @@ test:
 #          pytest-based e2e tests
 # ------------------------------------------
 
+
 venvpath     := ".venv"
 pip          := venvpath + "/bin/pip"
 python       := venvpath + "/bin/python"
 pytest       := venvpath + "/bin/pytest"
 
-test-e2e: setup-virtualenv build
-    @echo "Running e2e tests."
-    @{{pytest}} tests -vvvv
+# Run e2e tests.
+test-e2e *args: setup-virtualenv build
+    @echo
+    @echo "INFO: Running e2e tests."
+    @echo
+    {{pytest}} tests -vvvv {{args}}
 
-# Setup Python virtualenv
+# Setup Python virtualenv. This is used for running e2e tests with pytest.
 setup-virtualenv:
     #!/usr/bin/env sh
     if test ! -e {{python}}; then

--- a/README.md
+++ b/README.md
@@ -53,5 +53,10 @@ just test-e2e
 
 Invoke specific tests:
 ```bash
-pytest -k examples_basic -vvv
+
+# Address tests having `example` in their name.
+just test-e2e -k example
+
+# Address tests marked with `@pytest.mark.admin`.
+just test-e2e -m admin
 ```

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+markers =
+    admin: Tests for the admin REST API.

--- a/tests/test_admin_processor.py
+++ b/tests/test_admin_processor.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass, asdict
 from typing import Optional
 from enum import Enum
 
+import pytest
 import requests
 from requests import Response
 from lovely.testlayers.server import ServerLayer
@@ -29,6 +30,7 @@ def create_request_processor(rp: RequestProcessor) -> Response:
     return response
 
 
+@pytest.mark.admin
 def test_create_admin_processor(fh_http: ServerLayer):
     rp = RequestProcessor(
         id=None, name="testing", runtime="v8", language="javascript", code="my fun code"
@@ -45,6 +47,7 @@ def test_create_admin_processor(fh_http: ServerLayer):
     create_request_processor(rp2)
 
 
+@pytest.mark.admin
 def test_get_admin_processor(fh_http: ServerLayer):
     rp = RequestProcessor(
         id=None,
@@ -66,6 +69,7 @@ def test_get_admin_processor(fh_http: ServerLayer):
     assert data["code"] == data_get["code"]
 
 
+@pytest.mark.admin
 def test_update_admin_processor(fh_http: ServerLayer):
     rp = RequestProcessor(
         id=None, name="testing", runtime="v8", language="javascript", code="my fun code"
@@ -97,6 +101,7 @@ def test_update_admin_processor(fh_http: ServerLayer):
     assert data_update["code"] == data_get["code"]
 
 
+@pytest.mark.admin
 def test_delete_admin_processor(fh_http: ServerLayer):
     rp = RequestProcessor(
         id=None,
@@ -117,6 +122,7 @@ def test_delete_admin_processor(fh_http: ServerLayer):
     assert 404 == response_get.status_code
 
 
+@pytest.mark.admin
 def test_not_found_processor(fh_http: ServerLayer):
     id = "8a2e00e9-c710-4337-b717-bdcad0396df5"
     assert 404 == requests.post(f"http://localhost:3030/processor/{id}/run").status_code


### PR DESCRIPTION
Hi,

as I've seen you appreciated my humble contributions to the `Justfile` (thanks!), I've put some more efforts into it.

- Running `just` without any recipe target will now emit all available recipes, with comments.
- Accept variadic arguments to `just test-e2e`, thus forwarding them
  to pytest 1:1. That will allow to run a subset of available tests.

With kind regards,
Andreas.
