### PR TITLE
Bring preprocessor-based JavaScript IIFE module loading into the mix

### DIFF
--- a/examples/06-javascript-libs/01-basic-module/modhello.js
+++ b/examples/06-javascript-libs/01-basic-module/modhello.js
@@ -1,0 +1,15 @@
+// A very simple IIFE JavaScript module.
+var modhello = (function () {
+
+  var me = {};
+
+  me.echo = function(input) {
+    return input;
+  }
+
+  return me;
+}());
+
+if (typeof module === "object" && module.exports) {
+  module.exports = modhello;
+}

--- a/examples/06-javascript-libs/01-basic-module/userspace.js
+++ b/examples/06-javascript-libs/01-basic-module/userspace.js
@@ -1,0 +1,16 @@
+/**
+ *
+ * A basic example using an IIFE JavaScript module.
+ *
+ * This demonstrates the non-standard ``@fh:include``
+ * directive to include external JavaScript code.
+ *
+ * Currently, the machinery does not support Deno's Standard Library.
+ * Thus, its "import" directive is not available.
+ *
+**/
+
+// @fh:include("./modhello.js")
+
+var output = modhello.echo("Hello world.");
+Deno.core.print(output);

--- a/examples/06-javascript-libs/02-caesar-cipher/modcaesar.js
+++ b/examples/06-javascript-libs/02-caesar-cipher/modcaesar.js
@@ -1,0 +1,79 @@
+/**
+ *
+ * An IIFE JavaScript module implementing Caesar's cipher.
+ *
+ * - https://en.wikipedia.org/wiki/Caesar_cipher
+ * - https://codereview.stackexchange.com/questions/132125/rot13-javascript/252691#252691
+ *
+**/
+const modcaesar = (function () {
+
+  const this_ = {
+
+    caesar: function(string, shift) {
+
+      // Alphabet
+      const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+      // Encoded Text
+      let encodedText = '';
+
+      // Adjust Shift (Over 26 Characters)
+      if (shift > 26) {
+        // Assign Remainder As Shift
+        shift = shift % 26;
+      }
+
+      // Iterate Over Data
+      let i = 0;
+      while (i < string.length) {
+
+        let character = (string[i]).toUpperCase();
+
+        // Valid Alphabet Characters
+        if (alphabet.indexOf(character) !== -1) {
+          // Find Alphabet Index
+          const alphabetIndex = alphabet.indexOf(character);
+
+          // Alphabet Index Is In Alphabet Range
+          if (alphabet[alphabetIndex + shift]) {
+            // Append To String
+            encodedText += alphabet[alphabetIndex + shift];
+          }
+          // Alphabet Index Out Of Range (Adjust Alphabet By 26 Characters)
+          else {
+            // Append To String
+            encodedText += alphabet[alphabetIndex + shift - 26];
+          }
+        }
+        // Special Characters
+        else {
+          // Append To String
+          encodedText += string[i];
+
+        }
+
+        // Increase I
+        i++;
+      }
+
+      return encodedText;
+    },
+
+    rot12_encode: function(string) {
+      return this_.caesar(string, 12);
+    },
+
+    rot12_decode: function(string) {
+      return this_.caesar(string, 14);
+    }
+
+  };
+
+  return this_;
+
+}());
+
+if (typeof module === "object" && module.exports) {
+  module.exports = modcaesar;
+}

--- a/examples/06-javascript-libs/02-caesar-cipher/modquery.js
+++ b/examples/06-javascript-libs/02-caesar-cipher/modquery.js
@@ -1,0 +1,37 @@
+/**
+ *
+ * An IIFE JavaScript module implementing querystring encode/decode functions.
+ *
+ * Currently, the machinery does not support Deno's Standard Library.
+ * Thus, it's needed to supply respective polyfills.
+ *
+ * - https://github.com/denoland/deno/blob/master/std/node/querystring.ts
+ * - https://stackoverflow.com/questions/901115/how-can-i-get-query-string-values-in-javascript/2880929#2880929
+ *
+**/
+const modquery = (function () {
+
+  const this_ = {
+
+    parse: function(query) {
+      var match,
+        pl     = /\+/g,  // Regex for replacing addition symbol with a space
+        search = /([^&=]+)=?([^&]*)/g,
+        decode = function (s) { return decodeURIComponent(s.replace(pl, " ")); },
+
+      urlParams = {};
+      while (match = search.exec(query))
+        urlParams[decode(match[1])] = decode(match[2]);
+
+      return urlParams;
+    },
+
+  };
+
+  return this_;
+
+}());
+
+if (typeof module === "object" && module.exports) {
+  module.exports = modquery;
+}

--- a/examples/06-javascript-libs/02-caesar-cipher/userspace.js
+++ b/examples/06-javascript-libs/02-caesar-cipher/userspace.js
@@ -1,0 +1,36 @@
+/**
+ *
+ * A rot12 encoder/decoder example using an IIFE JavaScript
+ * module implementing Caesar's cipher.
+ *
+ * Also, it uses a pure JavaScript ``querystring.parse()`` function.
+ *
+ * This demonstrates the non-standard ``@fh:include``
+ * directive to include external JavaScript code.
+ *
+ * Currently, the machinery does not support Deno's Standard Library.
+ * Thus, its "import" directive is not available.
+ *
+**/
+
+// @fh:include("./modquery.js")
+// @fh:include("./modcaesar.js")
+
+// Read request.
+Deno.core.ops();
+let request = Deno.core.jsonOpSync("get_request", []);
+
+// Decode "x-www-form-urlencoded" form data.
+// https://morioh.com/p/480aef8e92cd
+let data = modquery.parse(request.body);
+
+// Use "payload" field;
+let payload = data.payload;
+
+
+// Apply rot12 encoding/decoding to payload content.
+var encoded = modcaesar.rot12_encode(payload);
+Deno.core.print("encoded: " + encoded + "\n");
+
+var decoded = modcaesar.rot12_decode(encoded);
+Deno.core.print("decoded: " + decoded + "\n");

--- a/examples/06-javascript-libs/05-htmlparser/parse-html.js
+++ b/examples/06-javascript-libs/05-htmlparser/parse-html.js
@@ -1,0 +1,24 @@
+/**
+ *
+ * An example using an IIFE JavaScript module for parsing HTML.
+ *
+ * It will include the "Pure JavaScript XML (pjxml)" library.
+ * https://github.com/smeans/pjxml
+ *
+ * This demonstrates the non-standard ``@fh:include``
+ * directive to include external JavaScript code.
+ *
+ * Currently, the machinery does not support Deno's Standard Library.
+ * Thus, its "import" directive is not available.
+ *
+**/
+
+// Include library from filesystem (inactive).
+/* // @fh:include("./lib/pjxml.js") */
+
+// Include library from the Web.
+// @fh:include("https://raw.githubusercontent.com/smeans/pjxml/4ea9516d/js/pjxml.js")
+
+var xml = '<document attribute="value"><name>David Bowie</name></document>';
+var doc = pjXML.parse(xml);
+Deno.core.print(JSON.stringify(doc));

--- a/tests/preprocessor.py
+++ b/tests/preprocessor.py
@@ -1,0 +1,87 @@
+import re
+from pathlib import Path
+from typing import Union
+
+import requests
+
+
+def preprocess_javascript(code: Union[str, Path]) -> str:
+    """
+    This is a hack to bring in non-standard
+    extensions to user space functions.
+
+    Currently, it implements the ``@fh:include()`` directive.
+
+    ``@fh:include()`` can include arbitrary code from
+    either the filesystem or from a HTTP resource.
+
+    :param code: The JavaScript code including custom extensions.
+    :return:     The resolved pure JavaScript code.
+    """
+
+    # Load entrypoint code either from
+    # filesystem or obtain it as string.
+    basedir = None
+    if isinstance(code, Path):
+        basedir = code.absolute().parent
+        with open(code, "r") as f:
+            jscode = f.read()
+    else:
+        jscode = code
+
+    # Implement the ``@fh:include`` directive.
+    if "// @fh:include" in jscode:
+        findings = re.findall(r"^(// @fh:include\(\"(.+?)\"\).*)", jscode, re.MULTILINE)
+        for finding in findings:
+            original, resource_address = finding
+            resource = load_resource(basedir, resource_address)
+            jscode = jscode.replace(original, resource)
+
+    return jscode
+
+
+def load_resource(basedir: Path, resource: str) -> str:
+    """
+    Load an external resource.
+    Either from the filesystem or from the Web.
+    When loading from the filesystem, it will prevent directory traversal.
+
+    :param basedir:  Path to base directory.
+    :param resource: Path to relative resource.
+    :return:         The string content of the resource.
+    """
+    payload = None
+    if resource.startswith("http"):
+        payload = requests.get(resource).text
+
+    elif basedir is not None:
+        file_resource = get_path_safe(basedir, resource)
+        if file_resource.exists():
+            with open(file_resource, "r") as f:
+                payload = f.read()
+
+    else:
+        raise NotImplemented(
+            f"Method for acquiring resource not implemented: {resource}"
+        )
+
+    if payload is None:
+        raise ImportError(f"Could not acquire resource {resource}")
+
+    return payload
+
+
+def get_path_safe(basedir: Path, resource: str) -> Path:
+    """
+    Resolve path to file.
+    Prevent directory traversal.
+
+    See also:
+    https://stackoverflow.com/questions/45188708/how-to-prevent-directory-traversal-attack-from-python-code
+
+    :param basedir:  Path pointing to basedir of the addressed resource.
+    :param resource: Relative path designating the addressed resource.
+    :return:         Safe path to the resource.
+    """
+    curdir = Path().absolute()
+    return basedir.joinpath(resource).resolve().relative_to(curdir)

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,11 @@
+# Testing
 pytest
 requests
+responses
 lovely-testlayers
 dacite
 python-dateutil
+
+# Code style
 black
+isort

--- a/tests/test_examples_jslib.py
+++ b/tests/test_examples_jslib.py
@@ -1,0 +1,82 @@
+import json
+from pathlib import Path
+
+from tests.conftest import FlowHeaterLayer
+from tests.util import execute
+from tests.preprocessor import preprocess_javascript
+
+basedir = Path("examples/06-javascript-libs")
+
+
+def test_modhello(fh_http: FlowHeaterLayer):
+
+    # ``fh-core`` doesn't know how to interpret
+    # the non-standard ``@fh:include()`` yet.
+    # So, let's resolve this in user space.
+    jsfile = basedir / "01-basic-module/userspace.js"
+    jscode = preprocess_javascript(jsfile)
+
+    response = execute(jscode)
+    assert response.status_code == 200
+
+    # Check STDOUT
+    stdout = fh_http.get_stdout()
+    assert stdout == "Hello world."
+
+
+def test_modcaesar(fh_http: FlowHeaterLayer):
+
+    # ``fh-core`` doesn't know how to interpret
+    # the non-standard ``@fh:include()`` yet.
+    # So, let's resolve this in user space.
+    jsfile = basedir / "02-caesar-cipher/userspace.js"
+    jscode = preprocess_javascript(jsfile)
+
+    response = execute(jscode, data={"payload": "Hello world."})
+    assert response.status_code == 200
+
+    # Check STDOUT
+    stdout = fh_http.get_stdout()
+    assert "encoded: TQXXA IADXP." in stdout
+    assert "decoded: HELLO WORLD." in stdout
+
+
+def test_htmlparser(fh_http: FlowHeaterLayer):
+
+    # ``fh-core`` doesn't know how to interpret
+    # the non-standard ``@fh:include()`` yet.
+    # So, let's resolve this in user space.
+    jsfile = basedir / "05-htmlparser/parse-html.js"
+    jscode = preprocess_javascript(jsfile)
+
+    response = execute(jscode)
+
+    assert response.status_code == 200
+    data = response.json()
+
+    # Check STDOUT
+    stdout = fh_http.get_stdout()
+
+    data = json.loads(stdout)
+
+    assert data == {
+        "type": 9,
+        "content": [
+            "",
+            {
+                "type": 1,
+                "content": [
+                    "",
+                    {
+                        "type": 1,
+                        "content": ["David Bowie"],
+                        "name": "name",
+                        "attributes": {},
+                    },
+                    "",
+                ],
+                "name": "document",
+                "attributes": {"attribute": "value"},
+            },
+        ],
+    }

--- a/tests/test_preprocessor.py
+++ b/tests/test_preprocessor.py
@@ -1,0 +1,64 @@
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+import responses
+
+from tests.preprocessor import get_path_safe, preprocess_javascript, load_resource
+
+
+@mock.patch("tests.preprocessor.load_resource", return_value="bazqux")
+def test_preprocess_include_filesystem(load_resource_patched: mock.Mock):
+    jscode_before = '// @fh:include("./foobar.js")'
+    jscode_after = preprocess_javascript(code=jscode_before)
+    load_resource_patched.assert_called_once()
+    assert jscode_after == "bazqux"
+
+
+@responses.activate
+def test_preprocess_include_url():
+    responses.add(responses.GET, "http://example.org/foobar.js", body="bazqux")
+    jscode_before = '// @fh:include("http://example.org/foobar.js")'
+    jscode_after = preprocess_javascript(code=jscode_before)
+    assert responses.assert_call_count("http://example.org/foobar.js", 1)
+    assert jscode_after == "bazqux"
+
+
+def test_load_resource_filesystem():
+    """
+    Load this testfile to demonstrate filesystem loading works.
+    """
+    basedir = Path(__file__).parent
+    resource = Path(__file__).name
+    payload = load_resource(basedir=basedir, resource=resource)
+    assert "test_load_resource_filesystem" in payload
+
+
+@responses.activate
+def test_load_resource_url():
+    responses.add(responses.GET, "http://example.org/foobar.js", body="bazqux")
+    payload = load_resource(basedir=None, resource="http://example.org/foobar.js")
+    assert payload == "bazqux"
+
+
+def test_get_path_safe_success():
+    outcome = get_path_safe(
+        basedir=Path("./path/to"), resource="./relative/resource.js"
+    )
+    assert outcome == Path("path/to/relative/resource.js")
+
+
+def test_get_path_safe_fail_traversal():
+    with pytest.raises(ValueError) as ex:
+        get_path_safe(basedir=Path("./path/to"), resource="../../../something/fishy.js")
+
+    if sys.version_info >= (3, 9):
+        assert ex.match(
+            "'.*?/something/fishy.js' is not in the subpath of '.*?' "
+            "OR one path is relative and the other is absolute."
+        )
+    else:
+        assert ex.match(
+            "'.*?/something/fishy.js' does not start with '.*?'"
+        )

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,5 +1,8 @@
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple, Union
+from pathlib import Path
+from typing import Union
+
 import requests
 from dacite import from_dict
 
@@ -25,14 +28,15 @@ class RequestConversation:
     audit_items: List[AuditItem]
 
 
-def read_code(filename) -> str:
-    with open(filename, "r") as f:
-        return f.read()
+def read_code(filename_or_code: Union[Path, str]) -> str:
+    if isinstance(filename_or_code, Path):
+        with open(filename_or_code, "r") as f:
+            return f.read()
+    else:
+        return filename_or_code
 
 
-def create_processor(filename) -> str:
-
-    code = read_code(filename)
+def create_processor(code: str):
 
     rp = RequestProcessor(
         id=None,
@@ -63,9 +67,13 @@ def run_processor(
     return response
 
 
-def execute(filename, method="get", prelude=False, **kwargs) -> requests.Response:
-    identifier = create_processor(filename)
+def execute(filename_or_code: Union[Path, str], method="get", prelude=False, **kwargs):
+
+    code = read_code(filename_or_code)
+
+    identifier = create_processor(code)
     response = run_processor(identifier, method=method, prelude=prelude, **kwargs)
+
     return response
 
 


### PR DESCRIPTION
Dear Tim,

as the machinery is not able to use the "import" module loading feature of Deno yet, this implementation based on a classic "preprocessor" technique will bring similar powers to the plate.

I was a bit hesitant at first, but then decided to give this a spin because it will enable so many more things in userspace. And things like "#include"-directives are not very esoteric in general and can be found within different kinds of implementations like [SSI](https://en.wikipedia.org/wiki/Server_Side_Includes) and many others.

By adding this feature, we will be able to load [JavaScript IIFE modules](https://developer.mozilla.org/en-US/docs/Glossary/IIFE) into user space code.

In order to implement this in a solid manner, I tried to take very much care to prevent things like file traversal flaws when accessing resources on the local filesystem and provide a thorough test harness for the preprocessor subsystem. I hope you appreciate my efforts.

In order to demonstrate the new features, I've added three tests.
- A demo including the simple module `modhello.js` from the local filesystem.
- A demo including the modules `modquery.js` and `modcaesar.js` from the local filesystem, implementing querystring encode/decode functions and the [Caesar's cipher](https://en.wikipedia.org/wiki/Caesar_cipher), for applying a rot12 encoder/decoder to an input payload parsed from a `x-www-urlencoded` request body.
- A demo including the [`pjxml`](https://github.com/smeans/pjxml) library from the Web in order to parse HTML.

With kind regards,
Andreas.
