### PR TITLE
Replace command calls with a macro

### DIFF
--- a/fh-http/src/server/conversation.rs
+++ b/fh-http/src/server/conversation.rs
@@ -41,23 +41,12 @@ pub(crate) mod handlers {
         id: Uuid,
         tx: ReqSender<ReqCmd>,
     ) -> Result<impl warp::Reply, warp::Rejection> {
-        let mut tx2 = tx
-            .lock()
-            .map_err(|e| warp::reject::custom(FhLockingError::new(e.to_string())))?
-            .clone();
-
-        let (resp_tx, resp_rx) = oneshot::channel();
-        tx2.send(ReqCmd::GetRequestConversation {
-            id,
-            cmd_tx: resp_tx,
-        })
-        .await
-        .map_err(|e| warp::reject::custom(FhHttpError::new(e)))?;
-
-        let res = resp_rx
-            .await
-            .map_err(|e| warp::reject::custom(FhHttpError::new(e)))?
-            .map_err(|e| warp::reject::custom(FhHttpError::new(e)))?;
+        let (cmd_tx, cmd_rx) = oneshot::channel();
+        let res = execute_command!(
+            tx,
+            ReqCmd::GetRequestConversation { id, cmd_tx: cmd_tx },
+            cmd_rx
+        );
 
         Ok(warp::reply::json(&res))
     }
@@ -66,23 +55,12 @@ pub(crate) mod handlers {
         id: Uuid,
         tx: ReqSender<ReqCmd>,
     ) -> Result<impl warp::Reply, warp::Rejection> {
-        let mut tx2 = tx
-            .lock()
-            .map_err(|e| warp::reject::custom(FhLockingError::new(e.to_string())))?
-            .clone();
-
-        let (resp_tx, resp_rx) = oneshot::channel();
-        tx2.send(ReqCmd::GetRequestConversationAuditItems {
-            id,
-            cmd_tx: resp_tx,
-        })
-        .await
-        .map_err(|e| warp::reject::custom(FhHttpError::new(e)))?;
-
-        let res = resp_rx
-            .await
-            .map_err(|e| warp::reject::custom(FhHttpError::new(e)))?
-            .map_err(|e| warp::reject::custom(FhHttpError::new(e)))?;
+        let (cmd_tx, cmd_rx) = oneshot::channel();
+        let res = execute_command!(
+            tx,
+            ReqCmd::GetRequestConversationAuditItems { id, cmd_tx: cmd_tx },
+            cmd_rx
+        );
 
         Ok(warp::reply::json(&res))
     }

--- a/fh-http/src/server/mod.rs
+++ b/fh-http/src/server/mod.rs
@@ -1,3 +1,7 @@
+// import this first, to have the macros available
+#[macro_use]
+mod util;
+
 pub(crate) mod admin;
 pub(crate) mod conversation;
 pub(crate) mod public;

--- a/fh-http/src/server/util.rs
+++ b/fh-http/src/server/util.rs
@@ -1,0 +1,33 @@
+#[macro_export]
+macro_rules! execute_command {
+    ($tx_db: ident, $tx_proc: ident, $cmd: expr, $cmd_rx: ident) => {{
+        let mut tx2 = $tx_proc
+            .lock()
+            .map_err(|e| warp::reject::custom(FhLockingError::new(e.to_string())))?
+            .clone();
+
+        tx2.send($cmd)
+            .await
+            .map_err(|e| warp::reject::custom(FhHttpError::new(e)))?;
+
+        $cmd_rx
+            .await
+            .map_err(|e| warp::reject::custom(FhHttpError::new(e)))?
+            .map_err(|e| warp::reject::custom(FhHttpError::new(e)))?
+    }};
+    ($tx_db: ident, $cmd: expr, $cmd_rx: ident) => {{
+        let mut tx2 = $tx_db
+            .lock()
+            .map_err(|e| warp::reject::custom(FhLockingError::new(e.to_string())))?
+            .clone();
+
+        tx2.send($cmd)
+            .await
+            .map_err(|e| warp::reject::custom(FhHttpError::new(e)))?;
+
+        $cmd_rx
+            .await
+            .map_err(|e| warp::reject::custom(FhHttpError::new(e)))?
+            .map_err(|e| warp::reject::custom(FhHttpError::new(e)))?
+    }};
+}


### PR DESCRIPTION
* Introduce `execute_command!` macro to simplify command invocation