### PR TITLE
Introduce Request/Response (de-)serialization (#25)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,6 +356,7 @@ name = "fh-core"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "reqwest",
  "serde",
  "sqlx",
  "tokio",

--- a/fh-core/Cargo.toml
+++ b/fh-core/Cargo.toml
@@ -12,3 +12,4 @@ warp = "0.2"
 anyhow = "1"
 serde = "1"
 sqlx = { version = "0.4", features = [ "sqlite", "runtime-tokio-rustls" ] }
+reqwest = "0.10"

--- a/fh-core/src/request.rs
+++ b/fh-core/src/request.rs
@@ -6,6 +6,8 @@ use std::{
 };
 use warp::http;
 
+use crate::{try_header_map_to_hashmap, version_to_string};
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct RequestSpec {
     pub request: Request,
@@ -14,30 +16,27 @@ pub struct RequestSpec {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Request {
-    pub headers: HashMap<String, String>,
+    pub headers: HashMap<String, Vec<String>>,
     pub body: String,
     pub method: String,
     pub path: String,
-    pub query: String,
+    pub query: Option<String>,
+    pub version: String,
 }
 
 impl TryFrom<http::Request<Vec<u8>>> for Request {
     type Error = anyhow::Error;
 
     fn try_from(req: http::Request<Vec<u8>>) -> Result<Self, Self::Error> {
-        let mut headers = HashMap::new();
-        for h in req.headers() {
-            headers.insert(h.0.to_string(), h.1.to_str()?.to_string());
-        }
-
         let (parts, body) = req.into_parts();
 
         Ok(Request {
             body: String::from_utf8(body)?,
-            headers,
+            headers: try_header_map_to_hashmap(parts.headers)?,
             method: parts.method.to_string(),
             path: parts.uri.path().to_string(),
-            query: parts.uri.query().unwrap_or("").to_string(),
+            query: parts.uri.query().and_then(|x| Some(x.to_string())),
+            version: version_to_string(parts.version),
         })
     }
 }

--- a/fh-http/src/server/public.rs
+++ b/fh-http/src/server/public.rs
@@ -115,7 +115,8 @@ pub(crate) mod handlers {
                 .get("FH-Conversation-Id")
                 .ok_or(warp::reject::custom(FhHttpError::new(anyhow::Error::msg(
                     "Missing response header 'FH-Conversation-Id'.",
-                ))))?,
+                ))))?[0]
+                .clone(),
         ))
     }
 
@@ -144,7 +145,8 @@ pub(crate) mod handlers {
                 .get("FH-Conversation-Id")
                 .ok_or(warp::reject::custom(FhHttpError::new(anyhow::Error::msg(
                     "Missing response header 'FH-Conversation-Id'.",
-                ))))?,
+                ))))?[0]
+                .clone(),
         ))
     }
 }

--- a/fh-v8/src/flow_heater.js
+++ b/fh-v8/src/flow_heater.js
@@ -1,10 +1,10 @@
 async function main(fh, request) {
-    await fh.log(`DENO: Got request body: ${request.body}, content-type header: ${request.headers['content-type']}, method: ${request.method}`);
+    await fh.log(`DENO: Got request body: ${request.body}, content-type header: ${request.headers}, method: ${request.method}`);
 
     // modify the requests data and return it back to the rust-context
     request.method = 'POST';
     request.body = "this is the patched body";
-    request.headers['content-type'] = 'application/json';
+    request.headers['content-type'] = ['application/json'];
 
     await fh.dispatch_request("http://httpbin.org/anything", request);
     await fh.log("Hello from Deno!");

--- a/fh-v8/src/lib.rs
+++ b/fh-v8/src/lib.rs
@@ -252,13 +252,13 @@ pub async fn process_request(
     let mut response_headers = HashMap::new();
     response_headers.insert(
         "FH-Conversation-Id".to_string(),
-        conversation_id.to_string(),
+        vec![conversation_id.to_string()],
     );
 
     Ok(Response {
         code: 200,
         headers: response_headers,
-        body: Some(
+        body: Some(String::from_utf8(
             rt_state
                 .request_list
                 .iter()
@@ -268,6 +268,7 @@ pub async fn process_request(
                 .body
                 .as_bytes()
                 .to_vec(),
-        ),
+        )?),
+        version: "HTTP/1.1".to_string(), // TODO: fill that with something useful
     })
 }

--- a/fh-v8/src/util.rs
+++ b/fh-v8/src/util.rs
@@ -10,6 +10,6 @@ macro_rules! execute_command {
 
         // HINT: never omit awaiting here... this leads to runtime hangs!
         // TODO: error handling?
-        $cmd_rx.await??;
+        $cmd_rx.await??
     }};
 }

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -10,32 +10,7 @@ def test_spike(fh_http: ServerLayer):
     # Check HTTP response.
     assert data["code"] == 200
     assert "fh-conversation-id" in response.headers
-    assert data["body"] == [
-        116,
-        104,
-        105,
-        115,
-        32,
-        105,
-        115,
-        32,
-        116,
-        104,
-        101,
-        32,
-        112,
-        97,
-        116,
-        99,
-        104,
-        101,
-        100,
-        32,
-        98,
-        111,
-        100,
-        121,
-    ]
+    assert data["body"] == "this is the patched body"
 
     # Check STDOUT for fun.
     fh_http.stdout.seek(0)

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -39,7 +39,11 @@ def test_audit_item_request(fh_http: FlowHeaterLayer):
     conversation_id = response.headers["fh-conversation-id"]
 
     (conversation, _response_conv) = get_request_conversation(conversation_id)
-    assert 1 == len(conversation.audit_items)
+    assert 2 == len(conversation.audit_items)
+    assert "request" == conversation.audit_items[0].kind
     assert "" == conversation.audit_items[0].payload["body"]
     assert "GET" == conversation.audit_items[0].payload["method"]
-    assert "" == conversation.audit_items[0].payload["query"]
+    assert None == conversation.audit_items[0].payload["query"]
+
+    assert "response" == conversation.audit_items[1].kind
+    assert 0 < len(conversation.audit_items[1].payload["body"])

--- a/tests/test_examples_basic.py
+++ b/tests/test_examples_basic.py
@@ -76,8 +76,8 @@ def test_json_request_get(fh_http: FlowHeaterLayer):
     data = json.loads(stdout)
     print(data)
     assert data["method"] == "GET"
-    assert data["headers"]["user-agent"].startswith("python-requests/")
-    assert data["headers"]["foo"] == "bar"
+    assert data["headers"]["user-agent"][0].startswith("python-requests/")
+    assert data["headers"]["foo"][0] == "bar"
     assert data["body"] == ""
 
 


### PR DESCRIPTION
* (De-)serialize `Request`s
* (De-)serialize `Response`s
* Store responses as `AuditItem`
* Closes #25