### PR TITLE
Implement `respond_with()` JS functionality (#20)

### DIFF
--- a/fh-v8/src/fh_prelude.js
+++ b/fh-v8/src/fh_prelude.js
@@ -27,6 +27,10 @@ class Fh {
         return await Deno.core.jsonOpAsync("dispatch_request", spec);
     };
 
+    async respond_with(response) {
+        return await Deno.core.jsonOpAsync("respond_with", response);
+    };
+
     get_request() {
         return Deno.core.jsonOpSync("get_request", []);
     };

--- a/fh-v8/src/flow_heater.js
+++ b/fh-v8/src/flow_heater.js
@@ -8,4 +8,13 @@ async function main(fh, request) {
 
     await fh.dispatch_request("http://httpbin.org/anything", request);
     await fh.log("Hello from Deno!");
+
+    await fh.respond_with({
+        code: 204,
+        headers: {
+            "content-type": ["application/xml"],
+        },
+        body: "xxx",
+        version: "HTTP/1.1",
+    })
 }

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -8,9 +8,10 @@ def test_spike(fh_http: ServerLayer):
     data = response.json()
 
     # Check HTTP response.
-    assert data["code"] == 200
+    assert data["code"] == 204
     assert "fh-conversation-id" in response.headers
-    assert data["body"] == "this is the patched body"
+    assert data["body"] == "xxx"
+    assert data["headers"]["content-type"][0] == "application/xml"
 
     # Check STDOUT for fun.
     fh_http.stdout.seek(0)

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -27,9 +27,9 @@ def test_audit_item_logging(fh_http: FlowHeaterLayer):
     conversation_id = response.headers["fh-conversation-id"]
 
     (conversation, _response_conv) = get_request_conversation(conversation_id)
-    assert 2 == len(conversation.audit_items)
-    assert '"Hello, World"' == conversation.audit_items[0].payload
-    assert '"Body is: "' == conversation.audit_items[1].payload
+    assert 3 == len(conversation.audit_items)
+    assert '"Hello, World"' == conversation.audit_items[1].payload
+    assert '"Body is: "' == conversation.audit_items[2].payload
 
 
 def test_audit_item_request(fh_http: FlowHeaterLayer):
@@ -39,11 +39,14 @@ def test_audit_item_request(fh_http: FlowHeaterLayer):
     conversation_id = response.headers["fh-conversation-id"]
 
     (conversation, _response_conv) = get_request_conversation(conversation_id)
-    assert 2 == len(conversation.audit_items)
+    assert 3 == len(conversation.audit_items)
     assert "request" == conversation.audit_items[0].kind
     assert "" == conversation.audit_items[0].payload["body"]
     assert "GET" == conversation.audit_items[0].payload["method"]
     assert None == conversation.audit_items[0].payload["query"]
 
-    assert "response" == conversation.audit_items[1].kind
-    assert 0 < len(conversation.audit_items[1].payload["body"])
+    assert "request" == conversation.audit_items[1].kind
+    assert 0 == len(conversation.audit_items[1].payload["body"])
+
+    assert "response" == conversation.audit_items[2].kind
+    assert 0 == len(conversation.audit_items[1].payload["body"])


### PR DESCRIPTION
* Introduce new JS core method `async respond_with(response)`, which could be called multiple times. The latest invocation sets the final response. If none is set, the body+headers from the last issued request is used.